### PR TITLE
installer: aggiungi requests, asf_search e shapely ai pacchetti Python

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -112,7 +112,8 @@ install-phase.ps1
    lancia l'installer (semi-interattivo, l'utente clicca Avanti×3).
 4. **Python** — auto-detect via `py -3.X` (X=11..20) escludendo `\WindowsApps\`.
    Se assente: download da python.org + silent install per-user (`/quiet
-   InstallAllUsers=0 PrependPath=1`) con progress bar. Poi `pip install openpyxl`.
+   InstallAllUsers=0 PrependPath=1`) con progress bar. Poi
+   `pip install openpyxl requests asf_search shapely`.
 5. **Cartella destinazione** — default `%USERPROFILE%\Desktop\PHASE`.
    Validazione: scrivibile, no OneDrive (warning, non blocco), no caratteri
    non-ASCII.

--- a/installer/install-phase.ps1
+++ b/installer/install-phase.ps1
@@ -458,10 +458,18 @@ function Install-PythonPackages {
         [Parameter(Mandatory)] [string]$PythonExe,
         [Parameter(Mandatory)] [scriptblock]$StatusCallback
     )
-    & $StatusCallback 'pip install openpyxl...'
-    $proc = Start-Process -FilePath $PythonExe -ArgumentList '-m', 'pip', 'install', '--upgrade', 'openpyxl' -Wait -PassThru -NoNewWindow
-    if ($proc.ExitCode -ne 0) {
-        throw "pip install openpyxl fallito con exit code $($proc.ExitCode)"
+    # Pacchetti Python richiesti da PHASE:
+    #   openpyxl    -> export/lettura Excel
+    #   requests    -> download HTTP
+    #   asf_search  -> ricerca e download dati SAR da ASF (Sentinel-1)
+    #   shapely     -> geometrie / footprint AOI
+    $packages = @('openpyxl', 'requests', 'asf_search', 'shapely')
+    foreach ($pkg in $packages) {
+        & $StatusCallback "pip install $pkg..."
+        $proc = Start-Process -FilePath $PythonExe -ArgumentList '-m', 'pip', 'install', '--upgrade', $pkg -Wait -PassThru -NoNewWindow
+        if ($proc.ExitCode -ne 0) {
+            throw "pip install $pkg fallito con exit code $($proc.ExitCode)"
+        }
     }
 }
 
@@ -1451,7 +1459,7 @@ function Invoke-StampsBinariesDownload {
             <!-- Page 4: Python -->
             <StackPanel x:Name="Page4_Python" Visibility="Collapsed">
                 <TextBlock Text="Python" FontSize="28" FontWeight="Light" Margin="0,0,0,10"/>
-                <TextBlock Text="PHASE requires Python 3.11 or newer with the openpyxl library. The installer can download and install it automatically."
+                <TextBlock Text="PHASE requires Python 3.11 or newer with the openpyxl, requests, asf_search and shapely libraries. The installer can download and install everything automatically."
                            TextWrapping="Wrap" FontSize="13" Foreground="#4A5168" Margin="0,0,0,20"/>
 
                 <TextBlock x:Name="PythonStatus" Text="" FontWeight="SemiBold" Margin="0,0,0,12"/>


### PR DESCRIPTION
Ho aggiunto requests, asf_search e shapely all'installer, così le dipendenze Python di PHASE si installano tutte in una volta e non solo openpyxl. La Install-PythonPackages adesso le scorre in loop, mostrando lo stato per ogni pacchetto e tirando l'errore giusto se una fallisce. Ho aggiornato di conseguenza il testo della pagina Python del wizard e il README dell'installer.

Una nota: install-phase.exe non l'ho rigenerato. Va ricompilato su Windows con compile-to-exe.ps1, sennò l'exe già buildato continua a installare solo openpyxl.